### PR TITLE
Encrypt the buildkite builder AMI disks

### DIFF
--- a/packer/linux/buildkite-ami.json
+++ b/packer/linux/buildkite-ami.json
@@ -23,7 +23,8 @@
       "ssh_username": "ec2-user",
       "ami_name": "buildkite-stack-linux-{{user `arch`}}-{{isotime | clean_resource_name}}",
       "ami_description": "Buildkite Elastic Stack (Amazon Linux 2 LTS w/ docker)",
-      "ami_groups": ["all"]
+      "ami_groups": ["all"],
+      "encrypt_boot": true
     }
   ],
   "provisioners": [


### PR DESCRIPTION
This will cause the resulting image boot volumes to also have disk encryption, to fit with our security policies in the environment. 