### PR TITLE
Pre-loaded docker images: use Postgres 16

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -394,7 +394,7 @@ function docker_pull_with_retry() {
   done
 }
 
-docker_pull_with_retry 'postgres:14'
+docker_pull_with_retry 'postgres:16'
 docker_pull_with_retry 'ruby:3.2.2-alpine'
 docker_pull_with_retry 'docker.elastic.co/elasticsearch/elasticsearch:7.17.5'
 docker_pull_with_retry 'redis:6'


### PR DESCRIPTION
This updates the docker images we pre-load onto our buildkite instances:

- postgres: 14 -> 16

We should merge this and rebuild the AMIs after the New Year's maintenance window.